### PR TITLE
Keep `@timestamp` and `@version` event fields to make them available to any processors.

### DIFF
--- a/src/main/java/co/elastic/logstash/filters/elasticintegration/IngestDuplexMarshaller.java
+++ b/src/main/java/co/elastic/logstash/filters/elasticintegration/IngestDuplexMarshaller.java
@@ -65,7 +65,14 @@ public class IngestDuplexMarshaller {
             // keep @timestamp and @version fields as it is to make available
             // to ingest pipelines (such as apache ingest pipelines) who proceed any operations on them
             if (eventKey.equals(org.logstash.Event.TIMESTAMP)) {
-                sourceAndMetadata.putIfAbsent(org.logstash.Event.TIMESTAMP, event.getField(org.logstash.Event.TIMESTAMP));
+                // if timestamp is `org.logstash.Timestamp` type, we convert to IngestDocument compatible timestamp
+                // elsewhere we keep it as it is
+                if (eventValue instanceof org.logstash.Timestamp) {
+                    ZonedDateTime zonedDateTimestamp = ZonedDateTime.ofInstant(((org.logstash.Timestamp) eventValue).toInstant(), UTC);
+                    sourceAndMetadata.putIfAbsent(org.logstash.Event.TIMESTAMP, zonedDateTimestamp);
+                } else {
+                    sourceAndMetadata.putIfAbsent(org.logstash.Event.TIMESTAMP, eventValue);
+                }
             } else if (eventKey.equals(org.logstash.Event.VERSION)) {
                 sourceAndMetadata.putIfAbsent(org.logstash.Event.VERSION, event.getField(org.logstash.Event.VERSION));
             } else {


### PR DESCRIPTION
### Issue description
There are ingest pipelines which are created by agent fleet. Some such pipelines such as apache2 access log, proceeds an operation on `@timestamp` field.

- Example, apache2 access pipeline first renames to `event.created`, assigns `@timestamp` with newly parsed value from `apache.access.time` and removes `apache.access.time`.

The issue is, we are not keeping `@timestamp` and `@version` fields when [converting from event to ES `IngestDocument`](https://github.com/mashhurs/logstash-filter-elastic_integration/blob/072ef3eb663f478d9eff38549602b692e0ecd987/src/main/java/co/elastic/logstash/filters/elasticintegration/IngestDuplexMarshaller.java#L57) and the pipelines who expect the `@timestamp` or `@version` fails with `field [@timestamp] doesn't exist` when running the processors.

- Closes #https://github.com/elastic/logstash-filter-elastic_integration/issues/58

### Acceptance Criteria
Any ingest processors who work without Logstash integration, should still behave same when Logstash is injected between. In other words, `IngestDocument` should contain all the fields from original even so that fleet ingest pipelines will be executed without issue.